### PR TITLE
Make the CLI drivable without a terminal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,8 @@ jobs:
           commit_message: Update go mod
           file_pattern: 'go.*'
       - name: Build
-        run: go build main.go
+        # ./... rather than main.go: package main is no longer a single file, and
+        # naming one file compiles only that file.
+        run: go build ./...
+      - name: Test
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+token.txt
+.idea
+AGENT-CLI-HANDOVER.md

--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # reclaim-cli
 A CLI for reclaim.ai
+
+Set `RECLAIM_API_KEY` to a personal Reclaim API key before use.
+
+## Interactive or not
+
+Every command still prompts for anything you do not pass as a flag, so running
+`reclaim create --title "..."` behaves exactly as it always has.
+
+Pass the flags instead and nothing is prompted for, which is what makes the CLI
+usable from a script or an agent. Prompting is skipped automatically when stdin is
+not a terminal, and `--non-interactive` forces the same behaviour when it is. In
+either case a missing flag is an immediate error rather than a prompt nobody can
+answer.
+
+Data goes to stdout and diagnostics to stderr, so `--json` output is safe to pipe.
+
+## `create`
+
+```bash
+reclaim create --title "Review the auth migration" \
+  --mins 30 --min-chunk 30 --priority P3 \
+  --start "in 1 week" --due 2026-08-14 --json
+```
+
+| Flag | |
+|---|---|
+| `--title` | required |
+| `--notes` | free text; a better home for links than the title |
+| `--mins` | total length: 15, 30, 45, 60, 90, 120, 180, 240 |
+| `--min-chunk` | shortest block it may be split into: 15, 30, 45, 60 |
+| `--priority` | P1, P2, P3, P4 |
+| `--start` | when to start working on it; snoozes the task until then |
+| `--due` | when it is due; omit for no due date |
+| `--json` | write the created task to stdout as one line of JSON |
+| `--non-interactive` | never prompt |
+
+`--mins` and `--min-chunk` are validated against the lists above, so a value the
+interactive picker would not have offered is rejected rather than turned into an
+odd chunk count.
+
+## `snooze`
+
+```bash
+reclaim snooze --id 13354745 --until "in 3 days"
+reclaim snooze --title "auth migration" --until 2026-09-01
+```
+
+`--id` and `--title` both skip the picker; `--title` matches on a case-insensitive
+substring of an open task's title and fails if more than one task matches.
+`--until` defaults to `in 1 day`.
+
+## Time values
+
+`--start`, `--due` and `--until` all accept:
+
+| Form | Example |
+|---|---|
+| `now` | `--start now` |
+| `in <n> hours\|days\|weeks` | `--until "in 3 days"` |
+| a date | `--due 2026-08-14` |
+| an RFC3339 timestamp | `--due 2026-08-14T17:30:00Z` |
+
+Bare dates are read in the local timezone. A bare `--start` or `--until` date
+begins at midnight; a bare `--due` date is due at 23:59, since a task due at
+midnight would be overdue for the whole of its due date.
+
+## Other commands
+
+| | |
+|---|---|
+| `reclaim dedupe` | merge tasks sharing a title, and delete tasks for GitLab MRs that are closed or merged. Needs `GITLAB_URL` and `GITLAB_TOKEN`. |
+| `reclaim archive` | archive completed tasks. `--auto-archive-age` archives anything finished more than that many days ago without asking; `--max-count` bounds how many you are asked about. `--non-interactive` archives on age alone. |
+| `reclaim meeting` | book a meeting through a scheduling link |
+| `reclaim version` | print the version |

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/petetanton/reclaim-cli/pkg/input"
+)
+
+// The option lists offered by the interactive prompts. Flag values are validated
+// against these same lists so that `--mins 37` fails loudly rather than being
+// turned into an odd chunk count.
+var (
+	minsOptions     = []int{15, 30, 45, 60, 90, 120, 180, 240}
+	minChunkOptions = []int{15, 30, 45, 60}
+	priorityOptions = []string{"P1", "P2", "P3", "P4"}
+	startOptions    = []string{NOW, IN_ONE_DAY, IN_TWO_DAYS, IN_ONE_WEEK}
+)
+
+// relativeSpec matches the generalised form of the IN_ONE_DAY-style presets, so
+// that "in 3 days" works as well as the four values the picker offers.
+var relativeSpec = regexp.MustCompile(`^in (\d+) (hour|hours|day|days|week|weeks)$`)
+
+// errNotInteractive explains why we are refusing to prompt. An agent driving the
+// CLI gets this immediately instead of hanging on a prompt it cannot answer.
+func errNotInteractive(flag string) error {
+	return fmt.Errorf("--%s is required when not running interactively (stdin is not a terminal, or --non-interactive was passed)", flag)
+}
+
+func validateIntChoice(flag string, value int, options []int) error {
+	if slices.Contains(options, value) {
+		return nil
+	}
+
+	allowed := make([]string, 0, len(options))
+	for _, option := range options {
+		allowed = append(allowed, strconv.Itoa(option))
+	}
+	return fmt.Errorf("invalid --%s %d: must be one of %s", flag, value, strings.Join(allowed, ", "))
+}
+
+func validateStringChoice(flag, value string, options []string) error {
+	if slices.Contains(options, value) {
+		return nil
+	}
+	return fmt.Errorf("invalid --%s %q: must be one of %s", flag, value, strings.Join(options, ", "))
+}
+
+// asStrings renders an int option list for the interactive picker.
+func asStrings(options []int) []string {
+	out := make([]string, 0, len(options))
+	for _, option := range options {
+		out = append(out, strconv.Itoa(option))
+	}
+	return out
+}
+
+// resolveIntChoice returns the flag's value when it was given, prompts for it
+// when prompting is possible, and otherwise fails fast. This is the precedence
+// that keeps the interactive experience unchanged for a human passing no flags.
+func resolveIntChoice(c *cli.Context, flag, question string, options []int, interactive bool) (int, error) {
+	if c.IsSet(flag) {
+		value := c.Int(flag)
+		if err := validateIntChoice(flag, value, options); err != nil {
+			return 0, err
+		}
+		return value, nil
+	}
+
+	if !interactive {
+		return 0, errNotInteractive(flag)
+	}
+
+	return strconv.Atoi(input.AskSelect(question, asStrings(options)))
+}
+
+func resolveStringChoice(c *cli.Context, flag, question string, options []string, interactive bool) (string, error) {
+	if c.IsSet(flag) {
+		value := c.String(flag)
+		if err := validateStringChoice(flag, value, options); err != nil {
+			return "", err
+		}
+		return value, nil
+	}
+
+	if !interactive {
+		return "", errNotInteractive(flag)
+	}
+
+	return input.AskSelect(question, options), nil
+}
+
+// parseTimeSpec resolves a user-supplied time expression relative to now.
+// Accepted forms:
+//
+//	now
+//	in <n> hours|days|weeks       e.g. "in 1 day", "in 3 days", "in 2 weeks"
+//	YYYY-MM-DD                    that date at bareDateHour:bareDateMin, local time
+//	an RFC3339 timestamp          e.g. "2026-08-04T09:15:00Z"
+//
+// Bare dates carry no time of day, so the caller supplies one: a start defaults
+// to the beginning of the day and a due date to the end of it, since a task due
+// at midnight would be overdue for the whole of its due date.
+func parseTimeSpec(spec string, now time.Time, bareDateHour, bareDateMin int) (time.Time, error) {
+	normalised := strings.Join(strings.Fields(strings.ToLower(spec)), " ")
+
+	if normalised == NOW {
+		return now, nil
+	}
+
+	if match := relativeSpec.FindStringSubmatch(normalised); match != nil {
+		count, err := strconv.Atoi(match[1])
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid time %q: %w", spec, err)
+		}
+
+		unit := strings.TrimSuffix(match[2], "s")
+		switch unit {
+		case "hour":
+			return now.Add(time.Hour * time.Duration(count)), nil
+		case "day":
+			return now.AddDate(0, 0, count), nil
+		case "week":
+			return now.AddDate(0, 0, count*7), nil
+		}
+	}
+
+	// A bare date is interpreted in the local zone, matching how someone reading
+	// "due on the 4th" means their own 4th rather than UTC's.
+	if date, err := time.ParseInLocation(time.DateOnly, normalised, now.Location()); err == nil {
+		return time.Date(date.Year(), date.Month(), date.Day(), bareDateHour, bareDateMin, 0, 0, now.Location()), nil
+	}
+
+	// Use the original spec here: RFC3339 is case-sensitive about its T and Z.
+	if timestamp, err := time.Parse(time.RFC3339, strings.TrimSpace(spec)); err == nil {
+		return timestamp, nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid time %q: expected %s, a date (2006-01-02), an RFC3339 timestamp, or \"in <n> hours|days|weeks\"", spec, strings.Join(startOptions, ", "))
+}
+
+// parseStartSpec resolves a --start or --until value. A bare date starts at
+// midnight.
+func parseStartSpec(spec string, now time.Time) (time.Time, error) {
+	return parseTimeSpec(spec, now, 0, 0)
+}
+
+// parseDueSpec resolves a --due value. A bare date is due at the end of that day.
+func parseDueSpec(spec string, now time.Time) (time.Time, error) {
+	return parseTimeSpec(spec, now, 23, 59)
+}

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A fixed zone keeps bare-date parsing deterministic and independent of the
+// machine's TZ and of DST transitions.
+var testZone = time.FixedZone("BST", 60*60)
+
+func testNow() time.Time {
+	return time.Date(2026, 7, 28, 10, 30, 0, 0, testZone)
+}
+
+func TestParseStartSpec(t *testing.T) {
+	now := testNow()
+
+	tests := map[string]struct {
+		spec string
+		want time.Time
+	}{
+		"now":                    {NOW, now},
+		"one day preset":         {IN_ONE_DAY, time.Date(2026, 7, 29, 10, 30, 0, 0, testZone)},
+		"two days preset":        {IN_TWO_DAYS, time.Date(2026, 7, 30, 10, 30, 0, 0, testZone)},
+		"one week preset":        {IN_ONE_WEEK, time.Date(2026, 8, 4, 10, 30, 0, 0, testZone)},
+		"generalised days":       {"in 3 days", time.Date(2026, 7, 31, 10, 30, 0, 0, testZone)},
+		"generalised weeks":      {"in 2 weeks", time.Date(2026, 8, 11, 10, 30, 0, 0, testZone)},
+		"generalised hours":      {"in 6 hours", time.Date(2026, 7, 28, 16, 30, 0, 0, testZone)},
+		"singular unit":          {"in 1 week", time.Date(2026, 8, 4, 10, 30, 0, 0, testZone)},
+		"zero is now":            {"in 0 days", now},
+		"mixed case":             {"In 1 Day", time.Date(2026, 7, 29, 10, 30, 0, 0, testZone)},
+		"extra whitespace":       {"  in   1   day  ", time.Date(2026, 7, 29, 10, 30, 0, 0, testZone)},
+		"bare date starts at 00": {"2026-08-04", time.Date(2026, 8, 4, 0, 0, 0, 0, testZone)},
+		"rfc3339 utc":            {"2026-08-04T09:15:00Z", time.Date(2026, 8, 4, 9, 15, 0, 0, time.UTC)},
+		"rfc3339 with offset":    {"2026-08-04T09:15:00+01:00", time.Date(2026, 8, 4, 8, 15, 0, 0, time.UTC)},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseStartSpec(test.spec, now)
+			require.NoError(t, err)
+			assert.True(t, test.want.Equal(got), "want %s, got %s", test.want, got)
+		})
+	}
+}
+
+// A task due at midnight would be overdue for the whole of its due date, so a
+// bare --due date resolves to the end of that day instead of the start.
+func TestParseDueSpec_bareDateIsEndOfDay(t *testing.T) {
+	got, err := parseDueSpec("2026-08-04", testNow())
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Date(2026, 8, 4, 23, 59, 0, 0, testZone), got)
+}
+
+func TestParseDueSpec_acceptsRelativeAndAbsolute(t *testing.T) {
+	now := testNow()
+
+	relative, err := parseDueSpec("in 1 week", now)
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 8, 4, 10, 30, 0, 0, testZone), relative)
+
+	absolute, err := parseDueSpec("2026-08-14T17:30:00Z", now)
+	require.NoError(t, err)
+	assert.True(t, time.Date(2026, 8, 14, 17, 30, 0, 0, time.UTC).Equal(absolute))
+}
+
+func TestParseTimeSpec_rejectsGarbage(t *testing.T) {
+	specs := []string{
+		"",
+		"tomorrow",
+		"next tuesday",
+		"in 1 fortnight",
+		"in a day",
+		"in days",
+		"in -1 days",
+		"1 day",
+		"2026-13-45",
+		"04/08/2026",
+		"2026-08-04 09:15",
+	}
+
+	for _, spec := range specs {
+		t.Run(spec, func(t *testing.T) {
+			_, err := parseStartSpec(spec, testNow())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid time")
+		})
+	}
+}
+
+func TestValidateIntChoice(t *testing.T) {
+	require.NoError(t, validateIntChoice("mins", 30, minsOptions))
+	require.NoError(t, validateIntChoice("mins", 240, minsOptions))
+
+	err := validateIntChoice("mins", 37, minsOptions)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --mins 37")
+	assert.Contains(t, err.Error(), "15, 30, 45, 60, 90, 120, 180, 240")
+}
+
+func TestValidateStringChoice(t *testing.T) {
+	require.NoError(t, validateStringChoice("priority", "P3", priorityOptions))
+
+	// Deliberately case-sensitive: the API only accepts the upper-case form.
+	err := validateStringChoice("priority", "p3", priorityOptions)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid --priority "p3"`)
+	assert.Contains(t, err.Error(), "P1, P2, P3, P4")
+}
+
+// The flags exist to replace the pickers, so a flag value the picker would not
+// have offered must be rejected. If these lists ever diverge, --mins 37 would
+// reach the API as an odd chunk count.
+func TestOptionListsMatchThePrompts(t *testing.T) {
+	assert.Equal(t, []int{15, 30, 45, 60, 90, 120, 180, 240}, minsOptions)
+	assert.Equal(t, []int{15, 30, 45, 60}, minChunkOptions)
+	assert.Equal(t, []string{"P1", "P2", "P3", "P4"}, priorityOptions)
+	assert.Equal(t, []string{"now", "in 1 day", "in 2 days", "in 1 week"}, startOptions)
+
+	// Every preset the picker offers must parse, or choosing it interactively
+	// would fail after the task had already been created.
+	for _, option := range startOptions {
+		_, err := parseStartSpec(option, testNow())
+		assert.NoError(t, err, "picker offers %q but it does not parse", option)
+	}
+}
+
+func TestErrNotInteractive_namesTheFlag(t *testing.T) {
+	err := errNotInteractive("mins")
+	assert.Contains(t, err.Error(), "--mins is required")
+	assert.Contains(t, err.Error(), "--non-interactive")
+}
+
+func TestAsStrings(t *testing.T) {
+	assert.Equal(t, []string{"15", "30", "45", "60"}, asStrings(minChunkOptions))
+}

--- a/main.go
+++ b/main.go
@@ -31,73 +31,78 @@ func main() {
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{
 		{
-			Name: "create",
+			Name:        "create",
+			Description: "Create a task. Any parameter not given as a flag is prompted for interactively.",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     "title",
 					Required: true,
 				},
+				&cli.StringFlag{
+					Name:  "notes",
+					Usage: "free-text notes on the task, a better home for links than the title",
+				},
+				&cli.IntFlag{
+					Name:  "mins",
+					Usage: "how long the task takes: " + strings.Join(asStrings(minsOptions), ", "),
+				},
+				&cli.IntFlag{
+					Name:  "min-chunk",
+					Usage: "shortest block the task may be split into: " + strings.Join(asStrings(minChunkOptions), ", "),
+				},
+				&cli.StringFlag{
+					Name:  "priority",
+					Usage: "one of " + strings.Join(priorityOptions, ", "),
+				},
+				&cli.StringFlag{
+					Name:  "start",
+					Usage: `when to start the task: "` + strings.Join(startOptions, `", "`) + `", "in <n> hours|days|weeks", a date (2006-01-02, from midnight) or an RFC3339 timestamp`,
+				},
+				&cli.StringFlag{
+					Name:  "due",
+					Usage: `when the task is due: "in <n> hours|days|weeks", a date (2006-01-02, due at 23:59) or an RFC3339 timestamp. Unset means no due date.`,
+				},
+				&cli.BoolFlag{
+					Name:  "json",
+					Usage: "write the created task to stdout as JSON",
+				},
+				&cli.BoolFlag{
+					Name:  "non-interactive",
+					Usage: "never prompt; fail if a required flag is missing. Implied when stdin is not a terminal.",
+				},
 			},
 			Action: func(c *cli.Context) error {
-				title := c.String("title")
-				mins := input.AskSelect("how many mins for the task", []string{"15", "30", "45", "60", "90", "120", "180", "240"})
-				minsInt, err := strconv.Atoi(mins)
-				if err != nil {
-					return err
-				}
-				minChunk := input.AskSelect("what is the min chunk length for the task", []string{"15", "30", "45", "60"})
-				minChunkInt, err := strconv.Atoi(minChunk)
-				if err != nil {
-					return err
-				}
-
-				minChunkSize := minChunkInt / 15
-
-				priority := input.AskSelect("what is the priority of the task", []string{"P1", "P2", "P3", "P4"})
-
-				task, err := client.CreateTask(title, minChunkSize, minChunkSize*8, minsInt/15, reclaim.TaskPriority(priority))
-				if err != nil {
-					return err
-				}
-				logrus.Infof("task %s created with id %d", title, task.Id)
-
-				delay := input.AskSelect("when would you like to start this task", []string{NOW, IN_ONE_DAY, IN_TWO_DAYS, IN_ONE_WEEK})
-				if delay == IN_ONE_DAY {
-					return client.SnoozeTask(task.Id, time.Now().Add(time.Hour*24))
-				}
-				if delay == IN_TWO_DAYS {
-					return client.SnoozeTask(task.Id, time.Now().Add(time.Hour*24*2))
-				}
-				if delay == IN_ONE_WEEK {
-					return client.SnoozeTask(task.Id, time.Now().Add(time.Hour*24*7))
-				}
-				return nil
+				return createTask(client, c)
 			},
 		},
 		{
 			Name:        "snooze",
 			Description: "Snooze a task so that it is scheduled at a later date",
+			Flags: []cli.Flag{
+				&cli.IntFlag{
+					Name:  "id",
+					Usage: "id of the task to snooze; skips the picker",
+				},
+				&cli.StringFlag{
+					Name:  "title",
+					Usage: "snooze the one open task whose title contains this text; skips the picker",
+				},
+				&cli.StringFlag{
+					Name:  "until",
+					Value: IN_ONE_DAY,
+					Usage: `when the task should next be scheduled: "` + strings.Join(startOptions, `", "`) + `", "in <n> hours|days|weeks", a date (2006-01-02) or an RFC3339 timestamp`,
+				},
+				&cli.BoolFlag{
+					Name:  "json",
+					Usage: "write the snoozed task to stdout as JSON",
+				},
+				&cli.BoolFlag{
+					Name:  "non-interactive",
+					Usage: "never prompt; fail if a required flag is missing. Implied when stdin is not a terminal.",
+				},
+			},
 			Action: func(c *cli.Context) error {
-				tasks, err := client.GetTasks([]string{})
-				if err != nil {
-					return err
-				}
-
-				var snoozableItems []string
-				for _, task := range tasks {
-					if task.Status != "COMPLETE" && task.Status != "ARCHIVED" {
-						snoozableItems = append(snoozableItems, fmt.Sprintf("%d, %s", task.Id, task.Title))
-					}
-				}
-
-				itemToSnooze := input.AskSelect("Which task would you like to snooze", snoozableItems)
-
-				idToSnooze, err := strconv.Atoi(strings.Split(itemToSnooze, ",")[0])
-				if err != nil {
-					return err
-				}
-
-				return client.SnoozeTask(idToSnooze, time.Now().Add(time.Hour*24))
+				return snoozeTask(client, c)
 			},
 		},
 		{
@@ -183,6 +188,7 @@ func main() {
 			Description: "Archive complete tasks",
 			Action: func(c *cli.Context) error {
 				noOfWorkers := 10
+				interactive := !c.Bool("non-interactive") && input.IsInteractive()
 				maxCount := c.Uint("max-count")
 				if maxCount == 0 {
 					maxCount = 10
@@ -218,7 +224,10 @@ func main() {
 					for _, task := range tasks {
 						if maxCount > 0 {
 							isOldTask := task.Finished.Before(time.Now().Add(time.Hour * 24 * time.Duration(autoArchiveAge) * -1))
-							if isOldTask || input.AskForConfirmation(fmt.Sprintf("Would you like to archive '%s': %v?", task.Title, task.Finished)) {
+							// Without a terminal there is nobody to answer the
+							// confirmation, so fall back to archiving purely on age
+							// rather than dying on the prompt.
+							if isOldTask || (interactive && input.AskForConfirmation(fmt.Sprintf("Would you like to archive '%s': %v?", task.Title, task.Finished))) {
 								logrus.Infof("Archiving task %d", task.Id)
 								taskToArchive <- task
 								if !isOldTask {
@@ -261,13 +270,18 @@ func main() {
 					Required: false,
 					Usage:    "no of days after which tasks should be auto archived",
 				},
+				&cli.BoolFlag{
+					Name:  "non-interactive",
+					Usage: "never prompt; archive only tasks older than --auto-archive-age. Implied when stdin is not a terminal.",
+				},
 			},
 		},
 		{
 			Name: "version",
 			Action: func(c *cli.Context) error {
-				logrus.Print(version.Version)
-				return nil
+				// stdout, not logrus: this is data a caller may want to read.
+				_, err := fmt.Fprintln(c.App.Writer, version.Version)
+				return err
 			},
 		},
 	}

--- a/output.go
+++ b/output.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/petetanton/reclaim-cli/pkg/reclaim"
+)
+
+// taskOutput is the machine-readable projection of a task written to stdout under
+// --json. It is a deliberate subset rather than the whole upstream shape, so
+// callers are not coupled to every field the API happens to return. logrus
+// diagnostics go to stderr, which keeps this side of the output pipeable.
+type taskOutput struct {
+	Id                 int        `json:"id"`
+	Title              string     `json:"title"`
+	Notes              string     `json:"notes,omitempty"`
+	Status             string     `json:"status"`
+	Priority           string     `json:"priority"`
+	Due                *time.Time `json:"due"`
+	SnoozeUntil        *time.Time `json:"snoozeUntil"`
+	TimeChunksRequired int        `json:"timeChunksRequired"`
+	MinChunkSize       int        `json:"minChunkSize"`
+	MaxChunkSize       int        `json:"maxChunkSize"`
+	EventCategory      string     `json:"eventCategory"`
+}
+
+func newTaskOutput(task *reclaim.Task) taskOutput {
+	return taskOutput{
+		Id:                 task.Id,
+		Title:              task.Title,
+		Notes:              task.Notes,
+		Status:             task.Status,
+		Priority:           task.Priority,
+		Due:                task.Due,
+		SnoozeUntil:        task.SnoozeUntil,
+		TimeChunksRequired: task.TimeChunksRequired,
+		MinChunkSize:       task.MinChunkSize,
+		MaxChunkSize:       task.MaxChunkSize,
+		EventCategory:      task.EventCategory,
+	}
+}
+
+// writeTaskJSON emits a task as a single line of JSON, so that
+// `reclaim create --json | jq .id` works without a second API round-trip.
+func writeTaskJSON(w io.Writer, task *reclaim.Task) error {
+	return json.NewEncoder(w).Encode(newTaskOutput(task))
+}

--- a/output_test.go
+++ b/output_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/petetanton/reclaim-cli/pkg/reclaim"
+)
+
+func TestWriteTaskJSON(t *testing.T) {
+	snoozeUntil := time.Date(2026, 8, 4, 9, 15, 0, 0, time.UTC)
+	task := &reclaim.Task{
+		Id:                 13354745,
+		Title:              `Review the "urgent" dashboard`,
+		Status:             "NEW",
+		Priority:           "P3",
+		SnoozeUntil:        &snoozeUntil,
+		TimeChunksRequired: 2,
+		MinChunkSize:       2,
+		MaxChunkSize:       16,
+		EventCategory:      "WORK",
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, writeTaskJSON(&out, task))
+
+	// One line, so the output composes with line-oriented tooling.
+	assert.Equal(t, 1, strings.Count(out.String(), "\n"))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &decoded))
+
+	assert.Equal(t, float64(13354745), decoded["id"])
+	assert.Equal(t, `Review the "urgent" dashboard`, decoded["title"])
+	assert.Equal(t, "2026-08-04T09:15:00Z", decoded["snoozeUntil"])
+	assert.Equal(t, float64(2), decoded["timeChunksRequired"])
+
+	// due is always present so callers can distinguish "no due date" from a field
+	// this CLI simply does not report.
+	assert.Contains(t, decoded, "due")
+	assert.Nil(t, decoded["due"])
+
+	// Notes are omitted when empty rather than reported as "".
+	assert.NotContains(t, decoded, "notes")
+}
+
+func TestWriteTaskJSON_includesDueWhenSet(t *testing.T) {
+	due := time.Date(2026, 8, 14, 17, 30, 0, 0, time.UTC)
+	task := &reclaim.Task{Id: 1, Due: &due, Notes: "some notes"}
+
+	var out bytes.Buffer
+	require.NoError(t, writeTaskJSON(&out, task))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &decoded))
+	assert.Equal(t, "2026-08-14T17:30:00Z", decoded["due"])
+	assert.Equal(t, "some notes", decoded["notes"])
+}

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -24,6 +24,15 @@ func isTerminal() bool {
 	return terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
+// IsInteractive reports whether prompts can actually be answered. survey needs a
+// real terminal to read from — piping answers on stdin does not work — so a
+// non-terminal stdin means callers must not prompt. Note this deliberately
+// checks stdin, unlike isTerminal above, which checks stdout to decide where
+// prompts are drawn.
+func IsInteractive() bool {
+	return terminal.IsTerminal(int(os.Stdin.Fd()))
+}
+
 func getAskOptions(options *survey.AskOptions) (err error) {
 	// use stdout if not piping
 	if isTerminal() {

--- a/pkg/reclaim/client.go
+++ b/pkg/reclaim/client.go
@@ -26,15 +26,19 @@ const (
 )
 
 type Client struct {
-	h      http.Client
-	apiKey string
+	h http.Client
+	// baseUrl is a field rather than the apiUrl constant so tests can point the
+	// client at a stub server.
+	baseUrl string
+	apiKey  string
 }
 
 func New() *Client {
 	return &Client{h: http.Client{
 		Timeout: time.Second * 10,
 	},
-		apiKey: os.Getenv("RECLAIM_API_KEY")}
+		baseUrl: apiUrl,
+		apiKey:  os.Getenv("RECLAIM_API_KEY")}
 }
 
 func (c *Client) do(req *http.Request) (*http.Response, error) {
@@ -44,18 +48,20 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 	return c.h.Do(req)
 }
 
-func (c *Client) CreateTask(title string, minChunkSize int, maxChunkSize int, timeChunksRequired int, priority TaskPriority) (*Task, error) {
-	requestBody := fmt.Sprintf(`{
-		"title": "%s",
-		"status": "NEW",
-		"minChunkSize": %d,
-		"maxChunkSize": %d,
-		"timeChunksRequired": %d,
-		"eventCategory": "WORK",
-		"priority": "%s"
-}`, title, minChunkSize, maxChunkSize, timeChunksRequired, priority)
-	request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/tasks", apiUrl), strings.NewReader(requestBody))
+func (c *Client) CreateTask(task *CreateTaskRequest) (*Task, error) {
+	if task.Status == "" {
+		task.Status = "NEW"
+	}
+	if task.EventCategory == "" {
+		task.EventCategory = "WORK"
+	}
 
+	requestBody, err := json.Marshal(task)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/tasks", c.baseUrl), strings.NewReader(string(requestBody)))
 	if err != nil {
 		return nil, err
 	}
@@ -66,53 +72,62 @@ func (c *Client) CreateTask(title string, minChunkSize int, maxChunkSize int, ti
 	}
 
 	defer response.Body.Close()
+	responseBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code %d when creating a task:\n%s", response.StatusCode, requestBody)
+		return nil, fmt.Errorf("unexpected status code %d when creating a task:\nrequest: %s\nresponse: %s", response.StatusCode, requestBody, responseBytes)
 	}
 
-	var task *Task
-	reqBytes, err := io.ReadAll(response.Body)
-	if err != nil {
+	var createdTask *Task
+	if err := json.Unmarshal(responseBytes, &createdTask); err != nil {
 		return nil, err
 	}
 
-	err = json.Unmarshal(reqBytes, &task)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return task, nil
+	return createdTask, nil
 }
 
-func (c *Client) SnoozeTask(taskId int, snoozeUntil time.Time) error {
-	requestBody := fmt.Sprintf(`{
-		"snoozeUntil": "%s"
-}`, snoozeUntil.Format(time.RFC3339Nano))
-	request, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/tasks/%d", apiUrl, taskId), strings.NewReader(requestBody))
-
+func (c *Client) SnoozeTask(taskId int, snoozeUntil time.Time) (*Task, error) {
+	requestBody, err := json.Marshal(&snoozeTaskRequest{SnoozeUntil: snoozeUntil})
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	request, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/tasks/%d", c.baseUrl, taskId), strings.NewReader(string(requestBody)))
+	if err != nil {
+		return nil, err
 	}
 
 	response, err := c.do(request)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code %d when snoozing a task:\n%s", response.StatusCode, requestBody)
+	responseBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d when snoozing a task:\nrequest: %s\nresponse: %s", response.StatusCode, requestBody, responseBytes)
+	}
+
+	var snoozedTask *Task
+	if err := json.Unmarshal(responseBytes, &snoozedTask); err != nil {
+		return nil, err
+	}
+
+	return snoozedTask, nil
 }
 
 func (c *Client) GetTasks(statuses []string) ([]*Task, error) {
 	if len(statuses) == 0 {
 		statuses = []string{"NEW", "SCHEDULED", "IN_PROGRESS", "COMPLETE"}
 	}
-	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/tasks?status=%s", apiUrl, strings.Join(statuses, ",")), nil)
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/tasks?status=%s", c.baseUrl, strings.Join(statuses, ",")), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +156,7 @@ func (c *Client) GetTasks(statuses []string) ([]*Task, error) {
 }
 
 func (c *Client) DeleteTask(taskId int) error {
-	request, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/tasks/%d", apiUrl, taskId), nil)
+	request, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/tasks/%d", c.baseUrl, taskId), nil)
 	if err != nil {
 		return err
 	}
@@ -165,7 +180,7 @@ func (c *Client) UpdateTask(task *Task) (*Task, error) {
 		return nil, err
 	}
 
-	request, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/tasks/%d", apiUrl, task.Id), strings.NewReader(string(requestBody)))
+	request, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/api/tasks/%d", c.baseUrl, task.Id), strings.NewReader(string(requestBody)))
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +209,7 @@ func (c *Client) UpdateTask(task *Task) (*Task, error) {
 
 func (c *Client) GetNextMeetingTime(linkId string) (*MeetingTime, error) {
 	now := time.Now()
-	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/scheduling-link/%s/meeting/availability/V2?date=%s&zoneId=Europe/London&conferenceType=ZOOM", apiUrl, linkId, now.Format("2006-01-02")), nil)
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/scheduling-link/%s/meeting/availability/V2?date=%s&zoneId=Europe/London&conferenceType=ZOOM", c.baseUrl, linkId, now.Format("2006-01-02")), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +239,7 @@ func (c *Client) GetNextMeetingTime(linkId string) (*MeetingTime, error) {
 }
 
 func (c *Client) GetScheduleLinks() ([]*ScheduleLink, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/scheduling-link", apiUrl), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/scheduling-link", c.baseUrl), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +287,7 @@ func (c *Client) CreateMeeting(inviteeName string, inviteeEmail string, title st
 
 	logrus.Info(string(requestBody))
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/scheduling-link/%s/meeting", apiUrl, linkId), strings.NewReader(string(requestBody)))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/scheduling-link/%s/meeting", c.baseUrl, linkId), strings.NewReader(string(requestBody)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reclaim/client_test.go
+++ b/pkg/reclaim/client_test.go
@@ -1,0 +1,143 @@
+package reclaim
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient points a Client at a stub server, capturing the request body it
+// sends so the encoding can be asserted on.
+func newTestClient(t *testing.T, response string, captured *[]byte) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		*captured = body
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = io.WriteString(w, response)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New()
+	client.baseUrl = server.URL
+	return client
+}
+
+// Titles used to be interpolated into a JSON string literal with fmt.Sprintf, so
+// any quote, backslash or newline produced a malformed body and an opaque API
+// error. An agent generating titles hits this routinely.
+func TestCreateTask_encodesAwkwardTitles(t *testing.T) {
+	titles := map[string]string{
+		"double quotes": `Review the "urgent" dashboard`,
+		"backslash":     `check C:\Users\ptanton\notes`,
+		"newline":       "first line\nsecond line",
+		"tab":           "before\tafter",
+		"json fragment": `{"title": "nested", "priority": "P1"}`,
+		"unicode":       "review café résumé — 日本語",
+	}
+
+	for name, title := range titles {
+		t.Run(name, func(t *testing.T) {
+			var captured []byte
+			client := newTestClient(t, `{"id": 1}`, &captured)
+
+			_, err := client.CreateTask(&CreateTaskRequest{
+				Title:              title,
+				MinChunkSize:       2,
+				MaxChunkSize:       16,
+				TimeChunksRequired: 2,
+				Priority:           P3,
+			})
+			require.NoError(t, err)
+
+			var decoded CreateTaskRequest
+			require.NoError(t, json.Unmarshal(captured, &decoded), "request body was not valid JSON: %s", captured)
+			assert.Equal(t, title, decoded.Title)
+		})
+	}
+}
+
+func TestCreateTask_defaultsStatusAndCategory(t *testing.T) {
+	var captured []byte
+	client := newTestClient(t, `{"id": 1}`, &captured)
+
+	_, err := client.CreateTask(&CreateTaskRequest{Title: "a task", Priority: P3})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(captured, &decoded))
+	assert.Equal(t, "NEW", decoded["status"])
+	assert.Equal(t, "WORK", decoded["eventCategory"])
+	assert.NotContains(t, decoded, "due", "an unset due must be omitted, not sent as the zero time")
+	assert.NotContains(t, decoded, "notes")
+}
+
+func TestCreateTask_sendsDueAndNotes(t *testing.T) {
+	var captured []byte
+	client := newTestClient(t, `{"id": 1}`, &captured)
+
+	due := time.Date(2026, 8, 14, 17, 30, 0, 0, time.UTC)
+	_, err := client.CreateTask(&CreateTaskRequest{Title: "a task", Priority: P3, Due: &due, Notes: "some notes"})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(captured, &decoded))
+	assert.Equal(t, "2026-08-14T17:30:00Z", decoded["due"])
+	assert.Equal(t, "some notes", decoded["notes"])
+}
+
+func TestCreateTask_readsBackTheCreatedTask(t *testing.T) {
+	var captured []byte
+	client := newTestClient(t, `{"id": 13354821, "title": "a task", "due": "2026-08-14T18:30:00+01:00", "snoozeUntil": null}`, &captured)
+
+	task, err := client.CreateTask(&CreateTaskRequest{Title: "a task", Priority: P3})
+	require.NoError(t, err)
+
+	assert.Equal(t, 13354821, task.Id)
+	require.NotNil(t, task.Due)
+	assert.Equal(t, time.Date(2026, 8, 14, 17, 30, 0, 0, time.UTC), task.Due.UTC())
+	assert.Nil(t, task.SnoozeUntil)
+}
+
+func TestSnoozeTask_returnsTheUpdatedTask(t *testing.T) {
+	var captured []byte
+	client := newTestClient(t, `{"id": 42, "snoozeUntil": "2026-08-05T09:00:00Z"}`, &captured)
+
+	snoozeUntil := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+	task, err := client.SnoozeTask(42, snoozeUntil)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(captured, &decoded))
+	assert.Equal(t, "2026-08-05T09:00:00Z", decoded["snoozeUntil"])
+
+	assert.Equal(t, 42, task.Id)
+	require.NotNil(t, task.SnoozeUntil)
+	assert.Equal(t, snoozeUntil, task.SnoozeUntil.UTC())
+}
+
+func TestCreateTask_errorIncludesResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"message":"minChunkSize must be positive"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New()
+	client.baseUrl = server.URL
+
+	_, err := client.CreateTask(&CreateTaskRequest{Title: "a task", Priority: P3})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "minChunkSize must be positive")
+}

--- a/pkg/reclaim/model.go
+++ b/pkg/reclaim/model.go
@@ -17,23 +17,47 @@ type Task struct {
 	AlwaysPrivate       bool    `json:"alwaysPrivate"`
 	Deleted             bool    `json:"deleted"`
 	Index               float64 `json:"index"`
-	//Due                 time.Time `json:"due"`  // this field is a strange format e.g. 0000-12-31T23:58:45-00:01:15
-	Created      time.Time `json:"created"`
-	Updated      time.Time `json:"updated"`
-	Finished     time.Time `json:"finished"`
-	Adjusted     bool      `json:"adjusted"`
-	AtRisk       bool      `json:"atRisk"`
-	TimeSchemeId string    `json:"timeSchemeId"`
-	Priority     string    `json:"priority"`
-	OnDeck       bool      `json:"onDeck"`
-	Deferred     bool      `json:"deferred"`
-	SortKey      float64   `json:"sortKey"`
+	// Due and SnoozeUntil are absent on most tasks, so they are pointers: a nil
+	// value is omitted on write rather than sent as the zero time, which the API
+	// rejects.
+	Due          *time.Time `json:"due,omitempty"`
+	SnoozeUntil  *time.Time `json:"snoozeUntil,omitempty"`
+	Created      time.Time  `json:"created"`
+	Updated      time.Time  `json:"updated"`
+	Finished     time.Time  `json:"finished"`
+	Adjusted     bool       `json:"adjusted"`
+	AtRisk       bool       `json:"atRisk"`
+	TimeSchemeId string     `json:"timeSchemeId"`
+	Priority     string     `json:"priority"`
+	OnDeck       bool       `json:"onDeck"`
+	Deferred     bool       `json:"deferred"`
+	SortKey      float64    `json:"sortKey"`
 	TaskSource   struct {
 		Type string `json:"type"`
 	} `json:"taskSource"`
 	ReadOnlyFields          []interface{} `json:"readOnlyFields"`
 	RecurringAssignmentType string        `json:"recurringAssignmentType"`
 	Type                    string        `json:"type"`
+}
+
+// CreateTaskRequest is the body of POST /api/tasks. It exists so request bodies
+// are built with json.Marshal rather than string interpolation, which produced
+// malformed JSON for any title containing a quote, backslash or newline.
+type CreateTaskRequest struct {
+	Title              string       `json:"title"`
+	Notes              string       `json:"notes,omitempty"`
+	Status             string       `json:"status"`
+	MinChunkSize       int          `json:"minChunkSize"`
+	MaxChunkSize       int          `json:"maxChunkSize"`
+	TimeChunksRequired int          `json:"timeChunksRequired"`
+	EventCategory      string       `json:"eventCategory"`
+	Priority           TaskPriority `json:"priority"`
+	Due                *time.Time   `json:"due,omitempty"`
+}
+
+// snoozeTaskRequest is the body of PATCH /api/tasks/{id}.
+type snoozeTaskRequest struct {
+	SnoozeUntil time.Time `json:"snoozeUntil"`
 }
 
 type MeetingResponse struct {

--- a/task.go
+++ b/task.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+
+	"github.com/petetanton/reclaim-cli/pkg/input"
+	"github.com/petetanton/reclaim-cli/pkg/reclaim"
+)
+
+// createTask resolves every parameter from its flag when given and falls back to
+// the interactive picker otherwise, so passing no flags behaves exactly as it
+// always has while an agent can supply everything up front.
+func createTask(client *reclaim.Client, c *cli.Context) error {
+	now := time.Now()
+	interactive := !c.Bool("non-interactive") && input.IsInteractive()
+
+	mins, err := resolveIntChoice(c, "mins", "how many mins for the task", minsOptions, interactive)
+	if err != nil {
+		return err
+	}
+
+	minChunk, err := resolveIntChoice(c, "min-chunk", "what is the min chunk length for the task", minChunkOptions, interactive)
+	if err != nil {
+		return err
+	}
+
+	priority, err := resolveStringChoice(c, "priority", "what is the priority of the task", priorityOptions, interactive)
+	if err != nil {
+		return err
+	}
+
+	// Resolve both times before creating anything: a malformed --start or --due
+	// should not leave a task behind that never got its schedule applied.
+	var due *time.Time
+	if c.IsSet("due") {
+		parsed, err := parseDueSpec(c.String("due"), now)
+		if err != nil {
+			return err
+		}
+		due = &parsed
+	}
+
+	startGivenAsFlag := c.IsSet("start")
+	startSpec := c.String("start")
+	if startGivenAsFlag {
+		if _, err := parseStartSpec(startSpec, now); err != nil {
+			return err
+		}
+	} else if !interactive {
+		return errNotInteractive("start")
+	}
+
+	title := c.String("title")
+	minChunkSize := minChunk / 15
+
+	task, err := client.CreateTask(&reclaim.CreateTaskRequest{
+		Title:              title,
+		Notes:              c.String("notes"),
+		MinChunkSize:       minChunkSize,
+		MaxChunkSize:       minChunkSize * 8,
+		TimeChunksRequired: mins / 15,
+		Priority:           reclaim.TaskPriority(priority),
+		Due:                due,
+	})
+	if err != nil {
+		return err
+	}
+	logrus.Infof("task %s created with id %d", title, task.Id)
+
+	// The start prompt deliberately stays after the create call, which is where it
+	// has always been in the interactive flow.
+	if !startGivenAsFlag {
+		startSpec = input.AskSelect("when would you like to start this task", startOptions)
+	}
+
+	startAt, err := parseStartSpec(startSpec, now)
+	if err != nil {
+		return err
+	}
+
+	// "now" and anything already in the past mean "do not snooze", which covers the
+	// NOW preset without having to compare strings.
+	if startAt.After(now) {
+		task, err = client.SnoozeTask(task.Id, startAt)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.Bool("json") {
+		return writeTaskJSON(os.Stdout, task)
+	}
+
+	return nil
+}
+
+// snoozeTask picks its target from --id, from --title, or from the interactive
+// list, in that order.
+func snoozeTask(client *reclaim.Client, c *cli.Context) error {
+	now := time.Now()
+	interactive := !c.Bool("non-interactive") && input.IsInteractive()
+
+	snoozeUntil, err := parseStartSpec(c.String("until"), now)
+	if err != nil {
+		return err
+	}
+
+	id, err := resolveTaskToSnooze(client, c, interactive)
+	if err != nil {
+		return err
+	}
+
+	task, err := client.SnoozeTask(id, snoozeUntil)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("task %d snoozed until %s", task.Id, snoozeUntil.Format(time.RFC3339))
+
+	if c.Bool("json") {
+		return writeTaskJSON(os.Stdout, task)
+	}
+
+	return nil
+}
+
+func resolveTaskToSnooze(client *reclaim.Client, c *cli.Context, interactive bool) (int, error) {
+	if c.IsSet("id") {
+		return c.Int("id"), nil
+	}
+
+	if !c.IsSet("title") && !interactive {
+		return 0, fmt.Errorf("--id or --title is required when not running interactively (stdin is not a terminal, or --non-interactive was passed)")
+	}
+
+	tasks, err := client.GetTasks([]string{})
+	if err != nil {
+		return 0, err
+	}
+
+	var snoozable []*reclaim.Task
+	for _, task := range tasks {
+		if task.Status != "COMPLETE" && task.Status != "ARCHIVED" {
+			snoozable = append(snoozable, task)
+		}
+	}
+
+	if c.IsSet("title") {
+		return matchTaskByTitle(snoozable, c.String("title"))
+	}
+
+	var snoozableItems []string
+	for _, task := range snoozable {
+		snoozableItems = append(snoozableItems, fmt.Sprintf("%d, %s", task.Id, task.Title))
+	}
+
+	itemToSnooze := input.AskSelect("Which task would you like to snooze", snoozableItems)
+
+	return strconv.Atoi(strings.Split(itemToSnooze, ",")[0])
+}
+
+// matchTaskByTitle requires exactly one match, listing the candidates otherwise,
+// so an ambiguous --title never silently snoozes the wrong task.
+func matchTaskByTitle(tasks []*reclaim.Task, title string) (int, error) {
+	needle := strings.ToLower(title)
+
+	var matches []*reclaim.Task
+	for _, task := range tasks {
+		if strings.Contains(strings.ToLower(task.Title), needle) {
+			matches = append(matches, task)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return 0, fmt.Errorf("no open task has a title containing %q", title)
+	case 1:
+		return matches[0].Id, nil
+	}
+
+	candidates := make([]string, 0, len(matches))
+	for _, task := range matches {
+		candidates = append(candidates, fmt.Sprintf("  %d  %s", task.Id, task.Title))
+	}
+	return 0, fmt.Errorf("%d open tasks have a title containing %q, pass --id for one of:\n%s", len(matches), title, strings.Join(candidates, "\n"))
+}


### PR DESCRIPTION
Every parameter of `create` was answered through an interactive survey picker, so a script or an agent had to allocate a pseudo-terminal and send arrow-key escape sequences. Those sequences are positional offsets into the option lists, so reordering any list silently changed what got selected.

Each picker now has a matching flag and is only reached when its flag is absent. Passing no flags behaves exactly as before, same prompts in the same order. Flag values are validated against the same option lists the pickers offer, so `--mins 37` fails loudly instead of becoming an odd chunk count.

Prompting is skipped when stdin is not a terminal, or on --non-interactive, and a missing flag then becomes an immediate error rather than a prompt nobody can answer. `archive` falls back to archiving on age alone in that case instead of dying on its confirmation prompt.

Also:

- `--json` writes the created or snoozed task to stdout, so callers no longer have to regex the task id out of a colour-coded logrus line on stderr.
- `--due` and `--notes` on create. Due dates were previously unreachable: only snoozeUntil was, via the start prompt, and "review this in a week" and "this is due in a week" are not the same thing.
- `snooze` takes --id, --title and --until. It was previously picker-only and always snoozed exactly 24h, which remains the --until default. An ambiguous --title lists the candidates rather than guessing.
- --start, --due and --until accept "in <n> hours|days|weeks", a bare date or an RFC3339 timestamp, not just the four hardcoded presets.
- `version` prints to stdout, since it is data rather than a diagnostic.

Request bodies are now built with json.Marshal rather than fmt.Sprintf into a JSON string literal. Any quote, backslash or newline in a title produced malformed JSON and an opaque API error, which matters much more once titles are machine-generated. Failed requests also report the response body.

Due and SnoozeUntil are added to Task as pointers, so an unset value is omitted on write rather than sent as the zero time. Verified against all 1781 tasks on the account: every non-null due parses as RFC3339, so the "strange format" comment this replaces no longer holds.

CI built `go build main.go`, which compiles only that one file; package main is no longer a single file. Switched to ./... and added a test step.